### PR TITLE
feat: Change data type to byte[] for sensitive data

### DIFF
--- a/PrivMX.Endpoint.Extra/Api/AsyncConnection.cs
+++ b/PrivMX.Endpoint.Extra/Api/AsyncConnection.cs
@@ -72,7 +72,7 @@ public sealed class AsyncConnection : IAsyncDisposable, IAsyncConnection
 	/// <param name="platformUrl">PrivMX Bridge URL.</param>
 	/// <param name="token">Cancelation token.</param>
 	/// <returns>Created and connected instance of the <see cref="Connection" />.</returns>
-	public static async Task<AsyncConnection> Connect(string userPrivateKey, string solutionId, string platformUrl,
+	public static async Task<AsyncConnection> Connect(byte[] userPrivateKey, string solutionId, string platformUrl,
 		CancellationToken token = default)
 	{
 		Logger.Log(LogLevel.Trace, "Connecting to {0}, solution {1}", platformUrl, solutionId);

--- a/PrivMX.Endpoint.Extra/ConnectionSession.cs
+++ b/PrivMX.Endpoint.Extra/ConnectionSession.cs
@@ -33,7 +33,7 @@ public sealed class ConnectionSession : IAsyncDisposable
 	private readonly AsyncThreadApi _threadApi;
 	private DisposeBool _disposed;
 
-	private ConnectionSession(string publicKey, string privateKey, AsyncConnection connection, AsyncThreadApi threadApi,
+	private ConnectionSession(string publicKey, byte[] privateKey, AsyncConnection connection, AsyncThreadApi threadApi,
 		AsyncStoreApi storeApi, AsyncInboxApi inboxApi)
 	{
 		_connection = connection;
@@ -52,7 +52,7 @@ public sealed class ConnectionSession : IAsyncDisposable
 	/// <summary>
 	///     Private key of the user. If connection is anonymous, this will be empty.
 	/// </summary>
-	public string PrivateKey { get; }
+	public byte[] PrivateKey { get; }
 
 	/// <summary>
 	///     Connection asynchronous api.
@@ -111,7 +111,7 @@ public sealed class ConnectionSession : IAsyncDisposable
 	/// <param name="platformUrl">Bridge url.</param>
 	/// <param name="token">Cancellation token.</param>
 	/// <returns>Authorized connection session.</returns>
-	public static async ValueTask<ConnectionSession> Create(string userPrivateKey, string publicKey, string solutionId,
+	public static async ValueTask<ConnectionSession> Create(byte[] userPrivateKey, string publicKey, string solutionId,
 		string platformUrl, CancellationToken token = default)
 	{
 		var connection = await ConnectionAsyncExtensions.ConnectAsync(userPrivateKey, solutionId, platformUrl, token);
@@ -129,10 +129,10 @@ public sealed class ConnectionSession : IAsyncDisposable
 		CancellationToken token = default)
 	{
 		var connection = await ConnectionAsyncExtensions.ConnectPublicAsync(solutionId, platformUrl, token);
-		return CreateInternal(connection, string.Empty, string.Empty);
+		return CreateInternal(connection, string.Empty, Array.Empty<byte>());
 	}
 
-	private static ConnectionSession CreateInternal(Connection connection, string publicKey, string privateKey)
+	private static ConnectionSession CreateInternal(Connection connection, string publicKey, byte[] privateKey)
 	{
 		var connectionId = connection.GetConnectionId();
 		var asyncConnection = new AsyncConnection(connection);

--- a/PrivMX.Endpoint.Extra/DefaultExtensions/BackendRequesterExtensions.cs
+++ b/PrivMX.Endpoint.Extra/DefaultExtensions/BackendRequesterExtensions.cs
@@ -30,7 +30,7 @@ public static class BackendRequesterAsyncExtensions
 	/// <param name="token">Cancellation token.</param>
 	/// <returns>JSON string representing raw server response.</returns>
 	public static ValueTask<string> BackendRequestAsync(this IBackendRequester backendRequester, string serverUrl,
-		string accessToken, string method, string paramsAsJson, CancellationToken token = default)
+		byte[] accessToken, string method, string paramsAsJson, CancellationToken token = default)
 	{
 		if (backendRequester is null)
 			throw new ArgumentNullException(nameof(backendRequester));
@@ -69,7 +69,7 @@ public static class BackendRequesterAsyncExtensions
 	/// <param name="token">Cancellation token.</param>
 	/// <returns>JSON string representing raw server response.</returns>
 	public static ValueTask<string> BackendRequestAsync(this IBackendRequester backendRequester, string serverUrl,
-		string apiKeyId, string apiKeySecret, long mode, string method, string paramsAsJson,
+		string apiKeyId, byte[] apiKeySecret, long mode, string method, string paramsAsJson,
 		CancellationToken token = default)
 	{
 		if (backendRequester is null)

--- a/PrivMX.Endpoint.Extra/DefaultExtensions/ConnectionAsyncExtensions.cs
+++ b/PrivMX.Endpoint.Extra/DefaultExtensions/ConnectionAsyncExtensions.cs
@@ -30,7 +30,7 @@ public static class ConnectionAsyncExtensions
 	/// <param name="platformUrl">PrivMX Bridge URL.</param>
 	/// <param name="token">Cancellation token.</param>
 	/// <returns>Created and connected instance of the Connection</returns>
-	public static ValueTask<Connection> ConnectAsync(string userPrivKey, string solutionId,
+	public static ValueTask<Connection> ConnectAsync(byte[] userPrivKey, string solutionId,
 		string platformUrl, CancellationToken token = default)
 	{
 		return WrapperCallsExecutor.Execute(

--- a/PrivMX.Endpoint.Extra/DefaultExtensions/InboxApiExtensions.cs
+++ b/PrivMX.Endpoint.Extra/DefaultExtensions/InboxApiExtensions.cs
@@ -74,7 +74,7 @@ public static class InboxApiExtensions
 	}
 
 	public static ValueTask<long> PrepareEntryAsync(this IInboxApi inboxApi, string inboxId, byte[] data,
-		List<long> inboxFileHandles, string userPrivKey, CancellationToken token = default)
+		List<long> inboxFileHandles, byte[] userPrivKey, CancellationToken token = default)
 	{
 		if (inboxApi is null)
 			throw new ArgumentNullException(nameof(inboxApi));

--- a/PrivMX.Endpoint.Extra/Internal/Inbox/InboxEntryWriterBuilder.cs
+++ b/PrivMX.Endpoint.Extra/Internal/Inbox/InboxEntryWriterBuilder.cs
@@ -25,7 +25,7 @@ public ref struct InboxEntryWriterBuilder(string inboxId, IInboxApi inboxApi)
 	private readonly Dictionary<string, (byte[] privateMeta, byte[] publicMeta, long lenght, byte? fillValue)> _files =
 		new();
 
-	private string? _privateKey;
+	private byte[]? _privateKey;
 
 	/// <summary>
 	///     Declares data to be written to the entry.
@@ -44,7 +44,7 @@ public ref struct InboxEntryWriterBuilder(string inboxId, IInboxApi inboxApi)
 	/// </summary>
 	/// <param name="privateKey">Private key</param>
 	/// <returns>Self</returns>
-	public InboxEntryWriterBuilder SetPrivateKey(string privateKey)
+	public InboxEntryWriterBuilder SetPrivateKey(byte[] privateKey)
 	{
 		_privateKey = privateKey;
 		return this;
@@ -79,7 +79,7 @@ public ref struct InboxEntryWriterBuilder(string inboxId, IInboxApi inboxApi)
 	}
 
 	private static async ValueTask<ManagedInboxEntryWriter> PrepareEntryAsync(IInboxApi inboxApi, string inboxId,
-		byte[] data, string? privateKye,
+		byte[] data, byte[]? privateKey,
 		Dictionary<string, (byte[] privateMeta, byte[] publicMeta, long lenght, byte? fillValue)> files,
 		CancellationToken token = default)
 	{
@@ -90,7 +90,7 @@ public ref struct InboxEntryWriterBuilder(string inboxId, IInboxApi inboxApi)
 			handles.Add(handle);
 		}
 
-		var entryHandle = await inboxApi.PrepareEntryAsync(inboxId, data, handles, privateKye!, token);
+		var entryHandle = await inboxApi.PrepareEntryAsync(inboxId, data, handles, privateKey!, token);
 		var streams = new Dictionary<string, InboxWriteFileStream>();
 		foreach (var (name, privateMeta, publicMeta, lenght, fillValue, handle) in files.Zip(handles,
 			         (pair, handle) => (pair.Key, pair.Value.privateMeta, pair.Value.publicMeta, pair.Value.lenght,


### PR DESCRIPTION
Change data type from "string" to "byte[]" for sensitive data for C# Extra wrapper.

Refs: #4, PECS-19