### PR TITLE
fix: Fix PrivateMeta property in StoreReadFileStream

### DIFF
--- a/PrivMX.Endpoint.Extra/Internal/Store/StoreReadFileStream.cs
+++ b/PrivMX.Endpoint.Extra/Internal/Store/StoreReadFileStream.cs
@@ -54,7 +54,7 @@ internal sealed class StoreReadonlyFileStream : PrivmxFileStream
 
 	public override string? FileId { get; }
 	public override ReadOnlySpan<byte> PublicMeta => _publicMeta;
-	public override ReadOnlySpan<byte> PrivateMeta => _publicMeta;
+	public override ReadOnlySpan<byte> PrivateMeta => _privateMeta;
 
 	public override void Flush()
 	{


### PR DESCRIPTION
Fix PrivateMata property to return PrivateMeta instead of PublicMeta in StoreReadonlyFileStream.

Refs: #6, PECS-21